### PR TITLE
Rename build npm script to avoid devDependencies installing as part of a parent npm install

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Rebuild Icons
         id: build-icons
         run: |
-          npm run build
+          npm run gen-sf-symbols
 
       - name: Check for modified symbols
         id: check-symbols
         run: echo modified=$(`git status --porcelain | grep -q symbols` && echo true || echo false) >> $GITHUB_OUTPUT
-      
+
       - name: Commit & Push Changes
         if: steps.check-symbols.outputs.modified == 'true'
         run: |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ automatically when branches are merged.
 ## Manually Updating
 
 1. Run `npm update-leo` to upgrade to latest Leo (which may have new icons)
-2. Run `npm run build` to regenerate symbols
+2. Run `npm run gen-sf-symbols` to regenerate symbols
 
 Once the `sf-icons` branch in Leo lands we can automatically update Leo.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "update-leo": "npm i github:brave/leo#main",
-    "build": "OUTPUT_FOLDER=symbols node node_modules/@brave/leo/src/scripts/gen-sf-icons.js"
+    "gen-sf-symbols": "OUTPUT_FOLDER=symbols node node_modules/@brave/leo/src/scripts/gen-sf-icons.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
https://docs.npmjs.com/cli/v9/configuring-npm/package-json#git-urls-as-dependencies